### PR TITLE
Add a Dockerfile for future Docker support Updated (fix fortunes.txt)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:latest
+
+# Install required packages
+RUN apk add --update --no-cache git python3 py3-pip
+
+# Clone the repository
+RUN git clone https://github.com/TheCommsChannel/TC2-BBS-mesh.git
+
+# Install Python dependencies
+RUN pip install --no-cache-dir --break-system-packages -r /TC2-BBS-mesh/requirements.txt
+
+# Copy configuration script
+COPY configini.sh /
+
+# Set permissions for configuration script
+RUN chmod +x /configini.sh
+
+# Define config volume
+VOLUME /config
+
+# Define working directory
+WORKDIR /config
+
+# Define the command to run
+CMD ["sh", "-c", " /configini.sh &&  python3 /TC2-BBS-mesh/server.py"]

--- a/docker/configini.sh
+++ b/docker/configini.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ ! -f "/config/config.ini" ]; then
+    cp "/TC2-BBS-mesh/config.ini" "/config/config.ini"
+fi

--- a/docker/configini.sh
+++ b/docker/configini.sh
@@ -2,3 +2,6 @@
 if [ ! -f "/config/config.ini" ]; then
     cp "/TC2-BBS-mesh/config.ini" "/config/config.ini"
 fi
+if [ ! -f "/config/fortunes.txt" ]; then
+    cp "/TC2-BBS-mesh/fortunes.txt" "/config/fortunes.txt"
+fi

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  tc2-bbs-mesh:
+    build: .
+    restart: always
+    volumes:
+      - ./config:/config
+    container_name: tc2-bbs-mesh


### PR DESCRIPTION
I forgot the docker fortunes.txt, here it is now. It would be great if you could include this in your repository, so I don't need to create my own and maintain it to build a container image. Whenever you make a change in the repo, I will automatically build a new image using a Jenkins pipeline.

Greetings from Austria.