### PR TITLE
Add the auto install script again with root check and documentation. (now uses get.docker.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,55 @@
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/B0B1OZ22Z)
 
-This is the TC²-BBS system integrated with Meshtastic devices. The system allows for message handling, bulletin boards, mail systems, and a channel directory.
+This is the TC²-BBS system integrated with Meshtastic devices. The system allows for message handling,bulletin boards, mail systems, and a channel directory.
 
-### Docker
+### Docker available
 
 If you're a Docker user, TC²-BBS Meshtastic is available on Docker Hub!
 
 [![Docker HUB](https://icon-icons.com/downloadimage.php?id=151885&root=2530/PNG/128/&file=docker_button_icon_151885.png)](https://hub.docker.com/r/thealhu/tc2-bbs-mesh)
 
-## Setup
+
+
+### Docker Automatic Script Deployment
+
+With this single command, TC²-BBS Meshtastic can be easily installed on Debian and all Debian-based Linux distributions, including Raspbian OS.
+**Warning:** To perform the installation, make sure you are in the root user. You can switch to the root user with sudo -i or su - root if you are not already.
+
+    curl -fsSL https://raw.githubusercontent.com/TheCommsChannel/TC2-BBS-mesh/main/docker/auto_docker_install_debian.sh | bash
+
+### Docker configuration:
+    
+After executing the Automatic Script Deployment command, TC²-BBS Meshtastic still needs to be configured. First, navigate to the installation directory where the Docker Compose definition is stored:
+
+    cd ./TC2-BBS-mesh-docker
+
+**This step is optional:** if the mestastic node is connected to the system via USB, we need to pass it through to the newly created Docker container so that it can control the USB device:
+
+nano docker-compose.yaml
+
+	# devices:                      <- uncomment if one of the two is needed
+	# - /dev/ttyUSB0:/dev/ttyUSB0   <- uncomment if needed
+	# - /dev/ttyACM0:/dev/ttyACM0   <- uncomment if needed
+
+To customize the config file of the TC²-BBS server software itself:
+
+    nano ./config/config.ini
+    
+After that, the TC²-BBS Meshtastic can simply be started as a service in the background:
+
+    docker compose up -d     
+    
+        #for debugging use:
+        docker compose up
+    	
+        #for stopping use:
+        docker compose down
+
+
+  
+
+## Setup manually 
 
 ### Requirements
 
@@ -54,7 +94,8 @@ If you're a Docker user, TC²-BBS Meshtastic is available on Docker Hub!
    pip install -r requirements.txt
    ```
 
-5. Set up the configuration in `config.ini`:  
+## Configure config.ini
+Set up the configuration in `config.ini`:  
    
    **[interface]**  
    If using `type = serial` and you have multiple devices connected, you will need to uncomment the `port =` line and enter the port of your device.   
@@ -85,7 +126,7 @@ If you're a Docker user, TC²-BBS Meshtastic is available on Docker Hub!
    bbs_nodes = !f53f4abc,!f3abc123  
    ```
 
-### Running the Server
+## Running the Server manually
 
 Run the server with:
 

--- a/docker/auto_docker_install_debian.sh
+++ b/docker/auto_docker_install_debian.sh
@@ -4,31 +4,19 @@ if [ "$EUID" -ne 0 ]; then
     echo -e "\e[31mERROR: This script must be run as root. Please switch to root using 'sudo -i' or 'su - root' and try again.\e[0m"
     exit 1
 fi
-if ! command -v docker &> /dev/null
-then
+if ! systemctl status docker &> /dev/null; then
     echo -e "\e[32mINFO: Install Docker...\e[0m"
-	# Add Docker's official GPG key:
-	apt-get update -y 
-	apt-get install ca-certificates curl -y
-	install -m 0755 -d /etc/apt/keyrings
-	curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-	chmod a+r /etc/apt/keyrings/docker.asc
-	# Add the repository to Apt sources:
-	echo \
-		"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
-		$(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-		tee /etc/apt/sources.list.d/docker.list > /dev/null
-	apt-get update -y
-	apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+    apt-get install curl -y
+    curl -fsSL https://get.docker.com | bash
 fi
 echo -e "\e[32mINFO: Docker is installed!\e[0m"
 if [ -e "./TC2-BBS-mesh-docker/docker-compose.yaml" ]; then
     echo -e "\e[32mINFO: TC2-BBS-mesh-docker folder is already present!\e[0m"
 else
-	echo -e "\e[32mINFO: Installing TC2-BBS-mesh Docker Container in $(pwd)/TC2-BBS-mesh-docker ...\e[0m"
+        echo -e "\e[32mINFO: Installing TC2-BBS-mesh Docker Container in $(pwd)/TC2-BBS-mesh-docker ...\e[0m"
     mkdir ./TC2-BBS-mesh-docker
-	cd TC2-BBS-mesh-docker
-	cat << EOF > docker-compose.yaml
+        cd TC2-BBS-mesh-docker
+        cat << EOF > docker-compose.yaml
 services:
   tc2-bbs-mesh:
     image: thealhu/tc2-bbs-mesh:latest
@@ -41,8 +29,8 @@ services:
  #     - /dev/ttyUSB0:/dev/ttyUSB0
  #     - /dev/ttyACM0:/dev/ttyACM0
 EOF
-	docker compose up
-	echo "" && 	echo ""
-	echo -e "\e[32mINFO: The TC2-BBS-mesh Docker container is now installed in $(pwd)/\e[0m"
-	echo -e "\e[32mINFO: Please make your changes to the configuration and then run ""$""docker compose up -d in $(pwd)/\e[0m"
+        docker compose up
+        echo "" &&      echo ""
+        echo -e "\e[32mINFO: The TC2-BBS-mesh Docker container is now installed in $(pwd)/\e[0m"
+        echo -e "\e[32mINFO: Please make your changes to the configuration and then run ""$""docker compose up -d in $(pwd)/\e[0m"
 fi

--- a/docker/auto_docker_install_debian.sh
+++ b/docker/auto_docker_install_debian.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Check if the script is run as root
+if [ "$EUID" -ne 0 ]; then
+    echo -e "\e[31mERROR: This script must be run as root. Please switch to root using 'sudo -i' or 'su - root' and try again.\e[0m"
+    exit 1
+fi
+if ! command -v docker &> /dev/null
+then
+    echo -e "\e[32mINFO: Install Docker...\e[0m"
+	# Add Docker's official GPG key:
+	apt-get update -y 
+	apt-get install ca-certificates curl -y
+	install -m 0755 -d /etc/apt/keyrings
+	curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+	chmod a+r /etc/apt/keyrings/docker.asc
+	# Add the repository to Apt sources:
+	echo \
+		"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+		$(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+		tee /etc/apt/sources.list.d/docker.list > /dev/null
+	apt-get update -y
+	apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+fi
+echo -e "\e[32mINFO: Docker is installed!\e[0m"
+if [ -e "./TC2-BBS-mesh-docker/docker-compose.yaml" ]; then
+    echo -e "\e[32mINFO: TC2-BBS-mesh-docker folder is already present!\e[0m"
+else
+	echo -e "\e[32mINFO: Installing TC2-BBS-mesh Docker Container in $(pwd)/TC2-BBS-mesh-docker ...\e[0m"
+    mkdir ./TC2-BBS-mesh-docker
+	cd TC2-BBS-mesh-docker
+	cat << EOF > docker-compose.yaml
+services:
+  tc2-bbs-mesh:
+    image: thealhu/tc2-bbs-mesh:latest
+    restart: always
+    volumes:
+      - ./config:/config
+    container_name: tc2-bbs-mesh
+ # -- These parameters are optional and can be uncommented if needed. --
+ #   devices:
+ #     - /dev/ttyUSB0:/dev/ttyUSB0
+ #     - /dev/ttyACM0:/dev/ttyACM0
+EOF
+	docker compose up
+	echo "" && 	echo ""
+	echo -e "\e[32mINFO: The TC2-BBS-mesh Docker container is now installed in $(pwd)/\e[0m"
+	echo -e "\e[32mINFO: Please make your changes to the configuration and then run ""$""docker compose up -d in $(pwd)/\e[0m"
+fi


### PR DESCRIPTION
Hello,

I have now implemented a check to see if the user is root. If not, they will be notified when they attempt to run the script. Additionally, please note that we are now using the installation script from get.docker.com.