### PR TITLE
Add note to readme regarding radio device role settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you would like to have the script automatically run at boot, follow the steps
    ```
 ## Radio Configuration
 
-Note: Radio must be set to **Client** mode, other modes the radio may allow the BBS to communicate for a short time then stops responding
+Note: Radio device role must be set to **CLIENT**, other roles may allow the BBS to communicate for a short time, but then the BBS will stop responding to requests
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ If you would like to have the script automatically run at boot, follow the steps
    ```sh
    sudo systemctl restart mesh-bbs.service
    ```
+## Radio Configuration
+
+Note: Radio must be set to **Client** mode, other modes the radio may allow the BBS to communicate for a short time then stops responding
 
 ## Features
 


### PR DESCRIPTION
In several days of testing with multiple mesh users we discovered the radio device role needs to be set to '**client**', if not then the BBS will stop responding to requests after approximately 30-40 minutes, sometimes less. 