### PR TITLE
Added error handling for non-integer inputs in mail selection

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -352,7 +352,7 @@ def handle_wall_of_shame_command(sender_id, interface):
 
 
 def handle_channel_directory_command(sender_id, interface):
-    response = "📚CHANNEL DIRECTORY📚\nWhat would you like to do?\n[V]iew  [P]ost  E[X]IT"
+    response = "📚CHANNEL DIRECTORY📚\nWhat would you like to do?\n[V]iew  \n[P]ost \n[R]emove \nE[X]IT"
     send_message(response, sender_id, interface)
     update_user_state(sender_id, {'command': 'CHANNEL_DIRECTORY', 'step': 1})
 
@@ -380,6 +380,16 @@ def handle_channel_directory_steps(sender_id, message, step, state, interface):
         elif choice == 'p':
             send_message("Name your channel for the directory:", sender_id, interface)
             update_user_state(sender_id, {'command': 'CHANNEL_DIRECTORY', 'step': 3})
+        elif choice == 'r':
+            channels = get_channels()
+            if channels:
+                response = "Select a channel number to remove:\n" + "\n".join(
+                    [f"[{i}] {channel[0]}" for i, channel in enumerate(channels)])
+                send_message(response, sender_id, interface)
+                update_user_state(sender_id, {'command': 'CHANNEL_DIRECTORY', 'step': 5})
+            else:
+                send_message("No channels available in the directory.", sender_id, interface)
+                handle_channel_directory_command(sender_id, interface
 
     elif step == 2:
         channel_index = int(message)
@@ -399,6 +409,15 @@ def handle_channel_directory_steps(sender_id, message, step, state, interface):
         channel_name = state['channel_name']
         add_channel(channel_name, channel_url)
         send_message(f"Your channel '{channel_name}' has been added to the directory.", sender_id, interface)
+        handle_channel_directory_command(sender_id, interface)
+
+    elif step == 5:
+        channel_index = int(message)
+        channels = get_channels()
+        if 0 <= channel_index < len(channels):
+            channel_name, _ = channels[channel_index]
+            remove_channel(channel_index)
+            send_message(f"Channel '{channel_name}' has been removed from the directory.", sender_id, interface)
         handle_channel_directory_command(sender_id, interface)
 
 

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -229,9 +229,7 @@ def handle_bb_steps(sender_id, message, step, state, interface, bbs_nodes):
 
 def handle_mail_steps(sender_id, message, step, state, interface, bbs_nodes):
     message = message.lower().strip()
-    if len(message) == 2 and message[1] == 'x':
-        message = message[0]
-
+    
     if step == 1:
         choice = message
         if choice == 'r':
@@ -252,17 +250,17 @@ def handle_mail_steps(sender_id, message, step, state, interface, bbs_nodes):
             handle_help_command(sender_id, interface)
 
     elif step == 2:
-        mail_id = int(message)
         try:
+            mail_id = int(message)
             sender_node_id = get_node_id_from_num(sender_id, interface)
             sender, date, subject, content, unique_id = get_mail_content(mail_id, sender_node_id)
             send_message(f"Date: {date}\nFrom: {sender}\nSubject: {subject}\n{content}", sender_id, interface)
             send_message("What would you like to do with this message?\n[K]eep  [D]elete  [R]eply", sender_id, interface)
             update_user_state(sender_id, {'command': 'MAIL', 'step': 4, 'mail_id': mail_id, 'unique_id': unique_id, 'sender': sender, 'subject': subject, 'content': content})
-        except TypeError:
-            logging.info(f"Node {sender_id} tried to access non-existent message")
-            send_message("Mail not found", sender_id, interface)
-            update_user_state(sender_id, None)
+        except ValueError:
+            send_message("Invalid input. Please enter a valid message number.", sender_id, interface)
+            # Optionally keep the user in the same state to try again
+            update_user_state(sender_id, {'command': 'MAIL', 'step': 2})
 
     elif step == 3:
         short_name = message.lower()

--- a/command_handlers.py
+++ b/command_handlers.py
@@ -389,7 +389,7 @@ def handle_channel_directory_steps(sender_id, message, step, state, interface):
                 update_user_state(sender_id, {'command': 'CHANNEL_DIRECTORY', 'step': 5})
             else:
                 send_message("No channels available in the directory.", sender_id, interface)
-                handle_channel_directory_command(sender_id, interface
+                handle_channel_directory_command(sender_id, interface)
 
     elif step == 2:
         channel_index = int(message)

--- a/db_operations.py
+++ b/db_operations.py
@@ -64,10 +64,14 @@ def add_channel(name, url, bbs_nodes=None, interface=None):
 def get_channels():
     conn = get_db_connection()
     c = conn.cursor()
-    c.execute("SELECT name, url FROM channels")
+    c.execute("SELECT id, name, url FROM channels")
     return c.fetchall()
 
-
+def remove_channel(id):
+    conn = get_db_connection()
+    c = conn.cursor()
+    c.execute("DELETE FROM channels WHERE id = ?", (id,))
+    conn.commit()
 
 def add_bulletin(board, sender_short_name, subject, content, bbs_nodes, interface, unique_id=None):
     conn = get_db_connection()


### PR DESCRIPTION
- Wrapped int() conversion in a try-except block to catch ValueError when users input non-numeric values.
- Provided user feedback for invalid input and allowed retrying in the same step.