### PR TITLE
Added check for None type values when adding all nodes together

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -135,7 +135,7 @@ def handle_stats_steps(sender_id, message, step, interface):
                     total_nodes = len(interface.nodes)
                 else:
                     time_limit = current_time - seconds
-                    total_nodes = sum(1 for node in interface.nodes.values() if node.get('lastHeard', 0) >= time_limit)
+                    total_nodes = sum(1 for node in interface.nodes.values() if node.get('lastHeard', 0) is not None and node.get('lastHeard', 0) >= time_limit)
                 total_nodes_summary.append(f"- {period}: {total_nodes}")
 
             response = "Total nodes seen:\n" + "\n".join(total_nodes_summary)


### PR DESCRIPTION
Issue:
    When fetching statistics for nodes and a node has no lastHeard value or has a null lastHeard value it becomes a None type which is not handled correctly.

Solution:
    Ignore all nodes with a None type lastSeen so they won't interfere with the calculation 