### PR TITLE
Fix TypeError in handle_stats_steps

### DIFF
--- a/command_handlers.py
+++ b/command_handlers.py
@@ -135,7 +135,7 @@ def handle_stats_steps(sender_id, message, step, interface):
                     total_nodes = len(interface.nodes)
                 else:
                     time_limit = current_time - seconds
-                    total_nodes = sum(1 for node in interface.nodes.values() if node.get('lastHeard', 0) >= time_limit)
+                    total_nodes = sum(1 for node in interface.nodes.values() if node.get('lastHeard') is not None and node['lastHeard'] >= time_limit)
                 total_nodes_summary.append(f"- {period}: {total_nodes}")
 
             response = "Total nodes seen:\n" + "\n".join(total_nodes_summary)


### PR DESCRIPTION
Fix TypeError in handle_stats_steps for NoneType comparison in node stats command.

This fixes the traceback when running: (U)tilities -> (S)tats -> (N)odes:

2024-11-22 13:57:00 - ERROR - Unexpected error in deferred execution <class 'TypeError'>
Traceback (most recent call last):
  File "/home/pi/TC2-BBS-mesh/venv/lib/python3.13/site-packages/meshtastic/util.py", line 297, in _run
    o()
    ~^^
  File "/home/pi/TC2-BBS-mesh/venv/lib/python3.13/site-packages/meshtastic/mesh_interface.py", line 1383, in <lambda>
    lambda: pub.sendMessage(topic, packet=asDict, interface=self)
            ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/venv/lib/python3.13/site-packages/pubsub/core/publisher.py", line 216, in sendMessage
    topicObj.publish(**msgData)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/venv/lib/python3.13/site-packages/pubsub/core/topicobj.py", line 452, in publish
    self.__sendMessage(msgData, topicObj, msgDataSubset)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/venv/lib/python3.13/site-packages/pubsub/core/topicobj.py", line 482, in __sendMessage
    listener(data, self, allData)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/venv/lib/python3.13/site-packages/pubsub/core/listener.py", line 237, in __call__
    cb(**kwargs)
    ~~^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/server-orig.py", line 71, in receive_packet
    on_receive(packet, interface)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/message_processing.py", line 203, in on_receive
    process_message(sender_id, message_string, interface, is_sync_message=False)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/message_processing.py", line 146, in process_message
    handle_stats_steps(sender_id, message, step, interface)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pi/TC2-BBS-mesh/command_handlers.py", line 138, in handle_stats_steps
    total_nodes = sum(1 for node in interface.nodes.values() if node.get('lastHeard', 0) >= time_limit)
  File "/home/pi/TC2-BBS-mesh/command_handlers.py", line 138, in <genexpr>
    total_nodes = sum(1 for node in interface.nodes.values() if node.get('lastHeard', 0) >= time_limit)
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'NoneType' and 'int'