### PR TITLE
Reduce Docker image size

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,36 @@
-FROM alpine:latest
+# From original Dockerfile at https://github.com/TheCommsChannel/TC2-BBS-mesh
+FROM debian:stable-slim AS build
 
-# Install required packages
-RUN apk add --update --no-cache git python3 py3-pip
+RUN apt-get update && \
+  apt-get install -y \
+  git \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Clone the repository
 RUN git clone https://github.com/TheCommsChannel/TC2-BBS-mesh.git
 
+####
+
+FROM --platform=$BUILDPLATFORM python:alpine
+
+# Switch to non-root user
+RUN adduser --disabled-password mesh
+USER mesh
+RUN mkdir -p /home/mesh/bbs
+WORKDIR /home/mesh/bbs
+
 # Install Python dependencies
-RUN pip install --no-cache-dir --break-system-packages -r /TC2-BBS-mesh/requirements.txt
+COPY --from=build /TC2-BBS-mesh/requirements.txt ./
+RUN pip install --no-cache-dir --break-system-packages -r requirements.txt
 
-# Copy configuration script
-COPY configini.sh /
-
-# Set permissions for configuration script
-RUN chmod +x /configini.sh
+# Copy over app code
+COPY --from=build /TC2-BBS-mesh/*.py ./
 
 # Define config volume
-VOLUME /config
-
-# Define working directory
-WORKDIR /config
+VOLUME /home/mesh/bbs/config
+WORKDIR /home/mesh/bbs/config
+COPY --from=build /TC2-BBS-mesh/example_config.ini ./config.ini
+COPY --from=build /TC2-BBS-mesh/fortunes.txt ./
 
 # Define the command to run
-CMD ["sh", "-c", " /configini.sh &&  python3 /TC2-BBS-mesh/server.py"]
+ENTRYPOINT [ "python3", "/home/mesh/bbs/server.py" ]

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -3,5 +3,5 @@ services:
     build: .
     restart: always
     volumes:
-      - ./config:/config
+      - ./config:/home/mesh/bbs/config
     container_name: tc2-bbs-mesh


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/84320405-94b2-407a-a503-7bf25b29a196)
Using a multi-stage build and a python specific base image to shave off some MB from the built image.

Also leveraging the entrypoint to simplify passing command line arguments to server.py running in the container 
example:
``` bash
> docker build --no-cache -t meshtastic-bbs .
> docker run --rm -it meshtastic-bbs --interface-type tcp --host 192.168.xxx.xxx
```