### PR TITLE
Adding viewing instructions to urgent bulletin notification.

### DIFF
--- a/db_operations.py
+++ b/db_operations.py
@@ -84,7 +84,7 @@ def add_bulletin(board, sender_short_name, subject, content, bbs_nodes, interfac
 
     # New logic to send group chat notification for urgent bulletins
     if board.lower() == "urgent":
-        notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}"
+        notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}\nDM "CB,,Urgent" to view"
         send_message(notification_message, BROADCAST_NUM, interface)
 
     return unique_id

--- a/message_processing.py
+++ b/message_processing.py
@@ -71,7 +71,7 @@ def process_message(sender_id, message, interface, is_sync_message=False):
             add_bulletin(board, sender_short_name, subject, content, [], interface, unique_id=unique_id)
 
             if board.lower() == "urgent":
-                notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}"
+                notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}\nDM "CB,,Urgent" to view"
                 send_message(notification_message, BROADCAST_NUM, interface)
         elif message.startswith("MAIL|"):
             parts = message.split("|")


### PR DESCRIPTION
Since the notifications go out on a public channel where some users may not be familiar with the BBS system, I think a very brief explanation on how to view the new urgent bulletin would be helpful. I tried to keep it as short as possible, but feel free to change the wording on it.