### PR TITLE
Corrected syntax by changing double quotes to single

### DIFF
--- a/db_operations.py
+++ b/db_operations.py
@@ -84,7 +84,7 @@ def add_bulletin(board, sender_short_name, subject, content, bbs_nodes, interfac
 
     # New logic to send group chat notification for urgent bulletins
     if board.lower() == "urgent":
-        notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}\nDM "CB,,Urgent" to view"
+        notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}\nDM 'CB,,Urgent' to view"
         send_message(notification_message, BROADCAST_NUM, interface)
 
     return unique_id

--- a/message_processing.py
+++ b/message_processing.py
@@ -71,7 +71,7 @@ def process_message(sender_id, message, interface, is_sync_message=False):
             add_bulletin(board, sender_short_name, subject, content, [], interface, unique_id=unique_id)
 
             if board.lower() == "urgent":
-                notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}\nDM "CB,,Urgent" to view"
+                notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}\nDM 'CB,,Urgent' to view"
                 send_message(notification_message, BROADCAST_NUM, interface)
         elif message.startswith("MAIL|"):
             parts = message.split("|")


### PR DESCRIPTION
I was tired when I made the last pull request and forgot that I can't use double quotes directly in a double-quoted string. Please merge this to avoid anyone hitting errors.

I made my request where you can change it: if you like the look of double quotes, you can change them back and escape them with a \ like this:
`notification_message = f"💥NEW URGENT BULLETIN💥\nFrom: {sender_short_name}\nTitle: {subject}\nDM \"CB,,Urgent\" to view"`

My apologies!